### PR TITLE
Change Releases link

### DIFF
--- a/firmware/readme.md
+++ b/firmware/readme.md
@@ -10,8 +10,8 @@ This page gives an overview of possible firmware downloads for the DiGidot C4 co
 ### Official and Beta
 All the official and beta firmwares, including the changelog, can be found on the releases page.
 
-* [Releases page](https://nextjs.org/)
+* [Releases page](https://github.com/Dennis-DiGidotTechnologiesBV/c4/releases)
 
 ### Custom
-If you're searching for custom firmware, click on the custom folder.
+If you're searching for custom firmware, click on the [custom folder](https://github.com/Dennis-DiGidotTechnologiesBV/c4/tree/master/firmware/custom).
 


### PR DESCRIPTION
The releases page went to NextJS website
Also now possible to click for the custom firmware folder